### PR TITLE
Add profile persistence pipeline and endpoints

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,27 +1,53 @@
 # app/api.py
-from fastapi import FastAPI, Depends
-from fastapi.responses import ORJSONResponse
-from .schemas import IngestPayload, ExtractPayload, ExtractionResult, Message
-from .config import settings
-from .deps import get_settings
-from .rag import RAG
-from .llm import LLMClient
-from .sgrops import SYSTEM_SGR, USER_TEMPLATE, schema_brief
-import orjson
+from __future__ import annotations
+
 from typing import List
+from uuid import UUID
+
+import orjson
+from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException
+from fastapi.responses import ORJSONResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .config import settings
+from .deps import get_session, get_settings
+from .llm import LLMClient
+from .profile_service import process_chat
+from .rag import RAG
+from .schemas import (
+    ContextEventResponse,
+    ExtractPayload,
+    ExtractionResult,
+    IngestPayload,
+    Message,
+    ProfileResponse,
+    UploadChatPayload,
+    UploadChatResponse,
+)
+from .sgrops import SYSTEM_SGR, USER_TEMPLATE, schema_brief
+from .db import Chat, ContextEvent, Profile, User, init_db
 
 app = FastAPI(default_response_class=ORJSONResponse)
 rag = RAG(settings.chroma_host, settings.chroma_port, settings.collection)
 llm = LLMClient()
 
+
+@app.on_event("startup")
+async def _startup() -> None:
+    await init_db()
+
+
 @app.get("/health")
 async def health():
     return {"ok": True}
+
 
 @app.post("/ingest")
 async def ingest(p: IngestPayload):
     rag.ingest(p.doc_id, p.text, p.metadata)
     return {"status": "ok"}
+
 
 def _truncate_dialog(dialog: List[Message], max_chars: int = 4000) -> List[Message]:
     acc, out = 0, []
@@ -32,6 +58,7 @@ def _truncate_dialog(dialog: List[Message], max_chars: int = 4000) -> List[Messa
         else:
             break
     return list(reversed(out))
+
 
 @app.post("/extract", response_model=ExtractionResult)
 async def extract(p: ExtractPayload, cfg=Depends(get_settings)):
@@ -50,3 +77,95 @@ async def extract(p: ExtractPayload, cfg=Depends(get_settings)):
     json_end = raw.rfind("}")
     cleaned = raw[json_start:json_end+1] if json_start != -1 else '{"items":[],"summary":"","confidence":0.0}'
     return ExtractionResult.model_validate_json(cleaned)
+
+
+def _normalize_user_id(user_id: str) -> str:
+    try:
+        return str(UUID(user_id))
+    except Exception:
+        return user_id
+
+
+async def _ensure_user(session: AsyncSession, user_id: str, email: str | None, external_id: str | None) -> User:
+    normalized_id = _normalize_user_id(user_id)
+    user = await session.get(User, normalized_id)
+    if user is None:
+        user = User(id=normalized_id, email=email, external_id=external_id)
+        session.add(user)
+        await session.flush()
+        return user
+
+    updated = False
+    if email and email != user.email:
+        user.email = email
+        updated = True
+    if external_id and external_id != user.external_id:
+        user.external_id = external_id
+        updated = True
+    if updated:
+        await session.flush()
+    return user
+
+
+@app.post("/upload_chat", response_model=UploadChatResponse)
+async def upload_chat(
+    payload: UploadChatPayload,
+    background: BackgroundTasks,
+    session: AsyncSession = Depends(get_session),
+) -> UploadChatResponse:
+    try:
+        chat_text = payload.resolve_text()
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    normalized_text = chat_text.strip()
+    if not normalized_text:
+        raise HTTPException(status_code=400, detail="Chat text cannot be empty")
+
+    user = await _ensure_user(session, payload.user_id, payload.email, payload.external_id)
+    chat = Chat(user_id=user.id, raw_text=normalized_text)
+    session.add(chat)
+    await session.flush()
+    chat_id = chat.id
+    await session.commit()
+
+    background.add_task(process_chat, chat_id)
+    return UploadChatResponse(chat_id=chat_id, status="queued")
+
+
+@app.get("/profile/{user_id}", response_model=ProfileResponse)
+async def get_profile(user_id: str, session: AsyncSession = Depends(get_session)) -> ProfileResponse:
+    normalized_id = _normalize_user_id(user_id)
+    profile = await session.get(Profile, normalized_id)
+    if profile is None:
+        raise HTTPException(status_code=404, detail="profile not found")
+
+    return ProfileResponse(
+        user_id=profile.user_id,
+        profile=profile.profile_json or {},
+        version=profile.version,
+        updated_at=profile.updated_at,
+    )
+
+
+@app.get("/profile/{user_id}/contexts", response_model=List[ContextEventResponse])
+async def list_contexts(user_id: str, session: AsyncSession = Depends(get_session)) -> List[ContextEventResponse]:
+    normalized_id = _normalize_user_id(user_id)
+    query = (
+        select(ContextEvent)
+        .where(ContextEvent.user_id == normalized_id)
+        .order_by(ContextEvent.timestamp.desc())
+    )
+    result = await session.execute(query)
+    events = result.scalars().all()
+    return [
+        ContextEventResponse(
+            id=event.id,
+            user_id=event.user_id,
+            chat_id=event.chat_id,
+            excerpt=event.excerpt,
+            derived_traits=event.derived_traits,
+            timestamp=event.timestamp,
+        )
+        for event in events
+    ]

--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 import os
 
+
 class Settings(BaseModel):
     llm_backend: str = os.getenv("LLM_BACKEND", "vllm")  # vllm | ollama
     llm_base_url: str = os.getenv("LLM_BASE_URL", "http://vllm:8000")
@@ -12,5 +13,9 @@ class Settings(BaseModel):
     timeout_ms: int = int(os.getenv("TIMEOUT_MS", "800"))
     top_p: float = float(os.getenv("TOP_P", "0.9"))
     temperature: float = float(os.getenv("TEMPERATURE", "0.2"))
+    database_url: str = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///./app.db")
+    analysis_max_traits: int = int(os.getenv("ANALYSIS_MAX_TRAITS", "5"))
+    profile_min_confidence: float = float(os.getenv("PROFILE_MIN_CONFIDENCE", "0.35"))
+
 
 settings = Settings()

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import AsyncGenerator, Optional
+
+from sqlalchemy import DateTime, ForeignKey, Integer, JSON, String, Text, func
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from .config import settings
+
+
+def _generate_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_generate_uuid)
+    email: Mapped[Optional[str]] = mapped_column(String(320), nullable=True)
+    external_id: Mapped[Optional[str]] = mapped_column(String(320), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class Chat(Base):
+    __tablename__ = "chats"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_generate_uuid)
+    user_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id", ondelete="CASCADE"), index=True)
+    raw_text: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class Profile(Base):
+    __tablename__ = "profiles"
+
+    user_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
+    profile_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+
+class ContextEvent(Base):
+    __tablename__ = "contexts"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_generate_uuid)
+    user_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id", ondelete="CASCADE"), index=True)
+    chat_id: Mapped[str] = mapped_column(String(36), ForeignKey("chats.id", ondelete="CASCADE"), index=True)
+    excerpt: Mapped[str] = mapped_column(Text, nullable=False)
+    derived_traits: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), index=True)
+
+
+_engine: Optional[AsyncEngine] = None
+_session_factory: Optional[async_sessionmaker[AsyncSession]] = None
+
+
+def configure_engine(database_url: Optional[str] = None) -> None:
+    """Configure engine/session factory. Safe to call multiple times (last call wins)."""
+
+    global _engine, _session_factory
+
+    database_url = database_url or settings.database_url
+    _engine = create_async_engine(database_url, future=True, echo=False)
+    _session_factory = async_sessionmaker(_engine, expire_on_commit=False)
+
+
+def get_engine() -> AsyncEngine:
+    if _engine is None:
+        configure_engine()
+    assert _engine is not None
+    return _engine
+
+
+def get_sessionmaker() -> async_sessionmaker[AsyncSession]:
+    if _session_factory is None:
+        configure_engine()
+    assert _session_factory is not None
+    return _session_factory
+
+
+async def init_db(drop_existing: bool = False) -> None:
+    engine = get_engine()
+    async with engine.begin() as conn:
+        if drop_existing:
+            await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+
+
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    session_factory = get_sessionmaker()
+    async with session_factory() as session:
+        yield session
+
+
+configure_engine()

--- a/app/deps.py
+++ b/app/deps.py
@@ -1,3 +1,16 @@
+from typing import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from .config import settings
+from .db import get_sessionmaker
+
+
 def get_settings():
     return settings
+
+
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    session_factory = get_sessionmaker()
+    async with session_factory() as session:
+        yield session

--- a/app/profile_service.py
+++ b/app/profile_service.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List, Tuple
+
+from sqlalchemy import select
+
+from .config import settings
+from .db import Chat, ContextEvent, Profile, get_sessionmaker
+
+
+@dataclass
+class TraitObservation:
+    name: str
+    confidence: float
+    excerpt: str
+
+
+@dataclass
+class ContextPayload:
+    excerpt: str
+    traits: List[str]
+
+
+_TRAIT_KEYWORDS: Dict[str, Tuple[str, ...]] = {
+    "optimistic": ("optimistic", "excited", "glad", "positive", "hopeful"),
+    "stressed": ("stressed", "worried", "anxious", "overwhelmed", "burned out"),
+    "decisive": ("decision", "decide", "commit", "finalize", "locked in"),
+    "collaborative": ("together", "team", "collaborate", "align", "sync"),
+    "detail_oriented": ("detail", "thorough", "careful", "checklist", "review"),
+    "leader": ("lead", "leadership", "drive", "ownership", "guide"),
+}
+
+
+def _make_excerpt(text: str, keyword: str, window: int = 120) -> str:
+    lowered = text.lower()
+    idx = lowered.find(keyword)
+    if idx == -1:
+        snippet = text[:window]
+    else:
+        start = max(0, idx - window // 2)
+        end = min(len(text), idx + len(keyword) + window // 2)
+        snippet = text[start:end]
+    normalized = " ".join(snippet.split())
+    return normalized[: window * 2].strip()
+
+
+def analyze_chat(text: str, max_traits: int | None = None) -> List[TraitObservation]:
+    """Heuristic extraction of personality traits from a chat body."""
+
+    max_traits = max_traits or settings.analysis_max_traits
+    lowered = text.lower()
+    observations: List[TraitObservation] = []
+    for trait, keywords in _TRAIT_KEYWORDS.items():
+        for keyword in keywords:
+            if keyword in lowered:
+                freq = lowered.count(keyword)
+                confidence = min(1.0, 0.55 + 0.1 * freq)
+                observations.append(
+                    TraitObservation(
+                        name=trait,
+                        confidence=round(confidence, 3),
+                        excerpt=_make_excerpt(text, keyword),
+                    )
+                )
+                break
+    if not observations and text.strip():
+        excerpt = " ".join(text.strip().split())[:200]
+        observations.append(TraitObservation(name="neutral", confidence=0.4, excerpt=excerpt))
+
+    filtered = [obs for obs in observations if obs.confidence >= settings.profile_min_confidence]
+    filtered.sort(key=lambda obs: obs.confidence, reverse=True)
+    return filtered[:max_traits]
+
+
+def merge_profiles(
+    existing: dict | None,
+    observations: Iterable[TraitObservation],
+    chat_id: str,
+    timestamp: datetime,
+) -> tuple[dict, List[ContextPayload]]:
+    """Merge observed traits into aggregated profile structure."""
+
+    profile = {"traits": {}}
+    if existing:
+        profile = {"traits": dict(existing.get("traits", {}))}
+        for trait_name, trait_payload in profile["traits"].items():
+            trait_payload.setdefault("confidence", 0.0)
+            trait_payload.setdefault("count", 1)
+            trait_payload.setdefault("evidence", [])
+            trait_payload.setdefault("first_seen", trait_payload.get("first_seen", timestamp.isoformat()))
+            trait_payload.setdefault("last_seen", trait_payload.get("last_seen", timestamp.isoformat()))
+
+    contexts_map: Dict[str, ContextPayload] = {}
+    for obs in observations:
+        trait = profile["traits"].get(obs.name)
+        if trait:
+            count = int(trait.get("count", 1))
+            running = float(trait.get("confidence", 0.0)) * count
+            new_conf = round(min(1.0, (running + obs.confidence) / (count + 1)), 3)
+            trait["confidence"] = new_conf
+            trait["count"] = count + 1
+            trait["last_seen"] = timestamp.isoformat()
+        else:
+            trait = {
+                "confidence": obs.confidence,
+                "count": 1,
+                "first_seen": timestamp.isoformat(),
+                "last_seen": timestamp.isoformat(),
+                "evidence": [],
+            }
+            profile["traits"][obs.name] = trait
+        evidence = trait.setdefault("evidence", [])
+        evidence.append(
+            {
+                "chat_id": chat_id,
+                "excerpt": obs.excerpt,
+                "confidence": obs.confidence,
+                "timestamp": timestamp.isoformat(),
+            }
+        )
+        contexts_map.setdefault(obs.excerpt, ContextPayload(excerpt=obs.excerpt, traits=[])).traits.append(obs.name)
+
+    contexts = list(contexts_map.values())
+    for ctx in contexts:
+        ctx.traits = sorted(set(ctx.traits))
+    return profile, contexts
+
+
+async def process_chat(chat_id: str) -> None:
+    """Process chat text, update user profile and store context events."""
+
+    session_factory = get_sessionmaker()
+    async with session_factory() as session:
+        chat = await session.get(Chat, chat_id)
+        if chat is None:
+            return
+
+        observations = analyze_chat(chat.raw_text, settings.analysis_max_traits)
+        if not observations:
+            return
+
+        timestamp = datetime.now(timezone.utc)
+        profile = await session.get(Profile, chat.user_id)
+        if profile is None:
+            profile = Profile(user_id=chat.user_id, profile_json={"traits": {}}, version=0, updated_at=timestamp)
+            session.add(profile)
+            await session.flush()
+
+        merged_profile, contexts = merge_profiles(profile.profile_json, observations, chat.id, timestamp)
+        profile.profile_json = merged_profile
+        profile.version = (profile.version or 0) + 1
+        profile.updated_at = timestamp
+
+        if contexts:
+            existing = await session.execute(
+                select(ContextEvent.chat_id, ContextEvent.excerpt, ContextEvent.derived_traits).where(
+                    ContextEvent.chat_id == chat.id
+                )
+            )
+            seen = {
+                (row.chat_id, row.excerpt, tuple(row.derived_traits))
+                for row in existing
+            }
+            for ctx in contexts:
+                key = (chat.id, ctx.excerpt, tuple(ctx.traits))
+                if key in seen:
+                    continue
+                session.add(
+                    ContextEvent(
+                        user_id=chat.user_id,
+                        chat_id=chat.id,
+                        excerpt=ctx.excerpt,
+                        derived_traits=ctx.traits,
+                        timestamp=timestamp,
+                    )
+                )
+
+        await session.commit()

--- a/app/rag.py
+++ b/app/rag.py
@@ -1,15 +1,55 @@
-import chromadb
-from chromadb.config import Settings
-from typing import List
+from __future__ import annotations
+
+from collections import deque
+from typing import Deque, Dict, List, Optional
+
+try:  # pragma: no cover - optional dependency
+    import chromadb  # type: ignore
+    from chromadb.config import Settings  # type: ignore
+except Exception:  # pragma: no cover - fallback when chromadb unavailable
+    chromadb = None
+    Settings = None
+
+
+class _InMemoryCollection:
+    """Minimal in-memory fallback for tests when ChromaDB is unavailable."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, str] = {}
+        self._order: Deque[str] = deque()
+        self._max_documents = 128
+
+    def upsert(self, documents: List[str], ids: List[str], metadatas: Optional[List[dict]] = None) -> None:
+        for doc_id, text in zip(ids, documents, strict=False):
+            self._store[doc_id] = text
+            self._order.append(doc_id)
+            if len(self._order) > self._max_documents:
+                oldest = self._order.popleft()
+                self._store.pop(oldest, None)
+
+    def query(self, query_texts: List[str], n_results: int = 4) -> dict:
+        # naive fallback: return most recent documents containing query terms
+        query = query_texts[0] if query_texts else ""
+        if not query:
+            items = list(self._store.values())[-n_results:]
+            return {"documents": [items]}
+        lowered = query.lower()
+        matches = [text for text in reversed(list(self._store.values())) if lowered in text.lower()]
+        return {"documents": [matches[:n_results]]}
+
 
 class RAG:
     def __init__(self, host: str, port: int, collection: str):
-        self.client = chromadb.Client(Settings(chroma_server_host=host, chroma_server_http_port=port))
-        self.col = self.client.get_or_create_collection(collection)
+        if chromadb is None:
+            self.client = None
+            self.col = _InMemoryCollection()
+        else:  # pragma: no cover - requires chromadb runtime
+            self.client = chromadb.Client(Settings(chroma_server_host=host, chroma_server_http_port=port))
+            self.col = self.client.get_or_create_collection(collection)
 
-    def ingest(self, doc_id: str, text: str, metadata: dict|None=None):
+    def ingest(self, doc_id: str, text: str, metadata: dict | None = None) -> None:
         self.col.upsert(documents=[text], ids=[doc_id], metadatas=[metadata or {}])
 
-    def query(self, q: str, k: int=4) -> List[str]:
+    def query(self, q: str, k: int = 4) -> List[str]:
         res = self.col.query(query_texts=[q], n_results=k)
         return res.get("documents", [[]])[0]

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,10 +1,17 @@
 # app/schemas.py
-from pydantic import BaseModel, Field
-from typing import List, Optional
+from __future__ import annotations
+
+import base64
+from datetime import datetime
+from typing import Any, List, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
 
 class Message(BaseModel):
     role: str  # "user" | "assistant" | "system"
     content: str
+
 
 class ContextItem(BaseModel):
     kind: str = Field(..., description="topic|task|question|decision|blocker|deadline")
@@ -13,16 +20,64 @@ class ContextItem(BaseModel):
     when: Optional[str] = None  # ISO8601 or relative
     weight: float = 1.0         # importance 0..1
 
+
 class ExtractionResult(BaseModel):
     items: List[ContextItem]
     summary: str
     confidence: float = 0.85
+
 
 class IngestPayload(BaseModel):
     doc_id: str
     text: str
     metadata: dict | None = None
 
+
 class ExtractPayload(BaseModel):
     dialog: List[Message]
     k: int = 4
+
+
+class UploadChatPayload(BaseModel):
+    user_id: str = Field(..., description="User identifier (UUID)")
+    text: Optional[str] = Field(default=None, description="Chat text payload")
+    file_b64: Optional[str] = Field(default=None, description="Base64 encoded chat text")
+    email: Optional[str] = Field(default=None)
+    external_id: Optional[str] = Field(default=None)
+
+    @model_validator(mode="after")
+    def validate_payload(cls, values: "UploadChatPayload") -> "UploadChatPayload":  # type: ignore[override]
+        if not values.text and not values.file_b64:
+            raise ValueError("Either 'text' or 'file_b64' must be provided")
+        return values
+
+    def resolve_text(self) -> str:
+        if self.text is not None:
+            return self.text
+        assert self.file_b64 is not None
+        try:
+            decoded = base64.b64decode(self.file_b64.encode("utf-8"), validate=True)
+        except Exception as exc:  # pragma: no cover - defensive
+            raise ValueError("file_b64 must be base64-encoded UTF-8 text") from exc
+        return decoded.decode("utf-8", errors="ignore")
+
+
+class UploadChatResponse(BaseModel):
+    chat_id: str
+    status: str = "queued"
+
+
+class ProfileResponse(BaseModel):
+    user_id: str
+    profile: dict[str, Any] = Field(default_factory=dict)
+    version: int
+    updated_at: Optional[datetime] = None
+
+
+class ContextEventResponse(BaseModel):
+    id: str
+    user_id: str
+    chat_id: str
+    excerpt: str
+    derived_traits: List[str]
+    timestamp: datetime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,15 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "fastapi>=0.110.0",
+    "uvicorn>=0.27.0",
+    "orjson>=3.9.10",
+    "pydantic>=2.6.0",
+    "sqlalchemy[asyncio]>=2.0.30",
+    "httpx>=0.27.0",
+    "aiosqlite>=0.19.0",
+    "asyncpg>=0.29.0",
 ]
-
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,12 +1,19 @@
 # tests/test_extract.py
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///./test_extract.db")
+
 import pytest
+
 from app.schemas import ExtractionResult, Message
 from app.api import _truncate_dialog
+
 
 def test_truncate():
     dialog = [Message(role="user", content="a"*1000) for _ in range(10)]
     out = _truncate_dialog(dialog, max_chars=2000)
     assert len(out) < len(dialog)
+
 
 def test_result_schema():
     # Проверяем, что схема адекватна при валидации

--- a/tests/test_profile_service.py
+++ b/tests/test_profile_service.py
@@ -1,0 +1,75 @@
+import asyncio
+from datetime import datetime, timezone
+from typing import Set
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import db as db_module
+from app.profile_service import TraitObservation, analyze_chat, merge_profiles, process_chat
+from app.api import app
+
+
+def test_analyze_chat_detects_traits():
+    text = "We should collaborate as a team and stay optimistic about the launch."
+    observations = analyze_chat(text, max_traits=5)
+    names: Set[str] = {obs.name for obs in observations}
+    assert "collaborative" in names
+    assert "optimistic" in names
+
+
+def test_merge_profiles_confidence_growth():
+    timestamp = datetime.now(timezone.utc)
+    base = {
+        "traits": {
+            "leader": {
+                "confidence": 0.6,
+                "count": 1,
+                "evidence": [],
+                "first_seen": timestamp.isoformat(),
+                "last_seen": timestamp.isoformat(),
+            }
+        }
+    }
+    observations = [TraitObservation(name="leader", confidence=0.9, excerpt="I will lead this project decisively")]
+    merged, contexts = merge_profiles(base, observations, "chat-1", timestamp)
+    assert merged["traits"]["leader"]["confidence"] > 0.6
+    assert contexts and contexts[0].traits == ["leader"]
+
+
+@pytest.fixture()
+def client(tmp_path):
+    db_path = tmp_path / "profiles.db"
+    db_url = f"sqlite+aiosqlite:///{db_path}"
+    db_module.configure_engine(db_url)
+    asyncio.run(db_module.init_db(drop_existing=True))
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_upload_and_fetch_profile_flow(client):
+    user_id = "11111111-1111-1111-1111-111111111111"
+    payload = {
+        "user_id": user_id,
+        "text": "I will lead the launch and collaborate with the team to stay optimistic.",
+        "email": "user@example.com",
+    }
+    response = client.post("/upload_chat", json=payload)
+    assert response.status_code == 200
+    chat_id = response.json()["chat_id"]
+
+    profile_resp = client.get(f"/profile/{user_id}")
+    if profile_resp.status_code == 404:
+        asyncio.run(process_chat(chat_id))
+        profile_resp = client.get(f"/profile/{user_id}")
+    assert profile_resp.status_code == 200
+    profile_data = profile_resp.json()
+    assert profile_data["version"] == 1
+    assert "traits" in profile_data["profile"]
+    assert "leader" in profile_data["profile"]["traits"]
+
+    contexts_resp = client.get(f"/profile/{user_id}/contexts")
+    assert contexts_resp.status_code == 200
+    contexts = contexts_resp.json()
+    assert contexts
+    assert any("leader" in ctx["derived_traits"] for ctx in contexts)


### PR DESCRIPTION
## Summary
- introduce SQLAlchemy models and async session utilities for users, chats, profiles, and context events
- add heuristic profile analysis pipeline, chat upload endpoint, and profile/context retrieval APIs with new schemas
- expand optional RAG fallback, configuration, dependencies, and tests covering analyzer logic and API integration

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cd786a5df08331aed2e6ec3791be77